### PR TITLE
Set Next.js assetPrefix for plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ NEXT_PUBLIC_CLIENT_SECRET=<client_secret> \
 npx next build && npx next export -o ../build
 ```
 
+The Next.js configuration now sets `assetPrefix` and `basePath` to
+`/wp-content/plugins/dah-next-plugin/build` so that the exported HTML loads its
+scripts and assets from the plugin directory.
+
 Replace `<client_id>` and `<client_secret>` with your credentials. The exported
 files will be written to `dah-next-plugin/build`.
 

--- a/dah-next-plugin/nextjs-app/src/next.config.js
+++ b/dah-next-plugin/nextjs-app/src/next.config.js
@@ -1,6 +1,10 @@
 
 // Define globals
+const pluginBasePath = '/wp-content/plugins/dah-next-plugin/build';
+
 module.exports = {
+  assetPrefix: pluginBasePath,
+  basePath: pluginBasePath,
   images: {
     domains: ['guesty-listing-images.s3.amazonaws.com', 'res.cloudinary.com', 'img.selfcateringlive.com', 'assets.guesty.com', 'lh3.googleusercontent.com']
   },


### PR DESCRIPTION
## Summary
- configure `next.config.js` with `assetPrefix` and `basePath` so built pages load assets from the plugin folder
- update build instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849df83808c8333867e12f6cc09ffa3